### PR TITLE
Support cloning parser state

### DIFF
--- a/src/lexical/fixed.rs
+++ b/src/lexical/fixed.rs
@@ -515,7 +515,7 @@ impl lexical::Error for Error {
     }
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 struct StoredContent {
     len: usize,
     escaped: bool,
@@ -609,6 +609,18 @@ pub struct FixedAnalyzer<B: Deref<Target = [u8]> + fmt::Debug> {
     err: Option<Error>,
     mach: state::Machine<state::DerefBuf<B, Arc<B>>>,
     pos: Pos,
+}
+
+impl<B: Deref<Target = [u8]> + fmt::Debug> Clone for FixedAnalyzer<B> {
+    fn clone(&self) -> Self {
+        Self {
+            buf: Arc::clone(&self.buf),
+            content: self.content,
+            err: self.err,
+            mach: self.mach.clone(),
+            pos: self.pos,
+        }
+    }
 }
 
 impl<B: Deref<Target = [u8]> + fmt::Debug> FixedAnalyzer<B> {
@@ -1350,6 +1362,27 @@ mod tests {
     )]
     fn test_analyzer_initial_state_err() {
         let _ = FixedAnalyzer::new(vec![]).err();
+    }
+
+    #[test]
+    fn test_analyzer_clone_forks_state() {
+        let mut analyzer = FixedAnalyzer::new(&b"[1,2]"[..]);
+        assert_eq!(Token::ArrBegin, analyzer.next());
+
+        let mut fork = analyzer.clone();
+
+        assert_eq!(Token::Num, analyzer.next());
+        assert_eq!("1", analyzer.content().literal());
+        assert_eq!(Token::ValueSep, analyzer.next());
+
+        assert_eq!(Token::Num, fork.next());
+        assert_eq!("1", fork.content().literal());
+        assert_eq!(Token::ValueSep, fork.next());
+
+        assert_eq!(Token::Num, analyzer.next());
+        assert_eq!("2", analyzer.content().literal());
+        assert_eq!(Token::ArrEnd, analyzer.next());
+        assert_eq!(Token::Eof, analyzer.next());
     }
 
     #[rstest]

--- a/src/lexical/state.rs
+++ b/src/lexical/state.rs
@@ -1482,6 +1482,16 @@ where
     B: Deref<Target = [u8]>,
     T: Deref<Target = B>;
 
+impl<B, T> Clone for DerefBuf<B, T>
+where
+    B: Deref<Target = [u8]>,
+    T: Deref<Target = B> + Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
 impl<B, T> DerefBuf<B, T>
 where
     B: Deref<Target = [u8]>,

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -871,6 +871,18 @@ pub struct Parser<L> {
     state: State,
 }
 
+impl<L: Clone> Clone for Parser<L> {
+    fn clone(&self) -> Self {
+        Self {
+            lexer: self.lexer.clone(),
+            context: self.context.clone(),
+            err: self.err.clone(),
+            max_level: self.max_level,
+            state: self.state,
+        }
+    }
+}
+
 impl<L> Parser<L>
 where
     L: lexical::Analyzer,


### PR DESCRIPTION
This adds Clone implementations to the Parser and FixedAnalyzer structs so that you can fork parse state and resume from an earlier point when desired.

If any changes are needed please say so.